### PR TITLE
Find libraries via pkgconfig

### DIFF
--- a/hcwiid.cabal
+++ b/hcwiid.cabal
@@ -22,10 +22,7 @@ Library
   GHC-Options:          -Wall
   Exposed-Modules:      System.CWiid
   Build-Depends:        base >= 4 && < 5, unix
-  Includes:             cwiid.h
-  Include-Dirs:         /usr/include, /usr/local/include, .
-  Extra-Libraries:      bluetooth, cwiid
-  Extra-Lib-Dirs:       /usr/lib, /usr/local/lib
+  Pkgconfig-Depends:    bluez, cwiid
   -- machine switch
   if os(linux)
     CPP-Options:        -DOS_Linux


### PR DESCRIPTION
Not all distributions have libraries in the standard paths. Using pkgconfig should be more reliable and avoids the need to hardcode paths to the library.

As an example, this patch makes hcwiid compile on NixOS. 
